### PR TITLE
Remove useless profanity and a useless comment

### DIFF
--- a/html/static/better.js
+++ b/html/static/better.js
@@ -257,10 +257,7 @@
 	};
 	Snip.UI.listing = function (index) {
 		// get the li element which represents the snip for given index
-		return el('[data-snipindex="' + index + '"]', this.snipList);
-		// I know I should not use dynamic css selectors without escaping
-		// or better not use dynamic css selectors at all
-		// but fuck you
+		return el('[data-snipindex=' + index + ']', this.snipList);
 	};
 	Snip.UI.createUI = function () {
 		this.currSnip = el.cl('current-snippet');


### PR DESCRIPTION
Nothing can go wrong in this selector. No need to escape at all, it's fine.