### PR TITLE
Cleaner test of property

### DIFF
--- a/html/static/modules.js
+++ b/html/static/modules.js
@@ -1,7 +1,7 @@
 function setDefaults (on, def) {
 
 	Object.keys(def).forEach(function(key){
-		if (typeof on[key] === "undefined") {
+		if (on[key] === undefined) {
 			on[key] = def[key];
 		}
 	}, on);


### PR DESCRIPTION
The proper way to test if a property is defined isn't to use typeof. `typeof` is only needed for variables (to avoid an error in case of undefined variable).